### PR TITLE
Add package.json with Vite setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Divide Like a King
+
+This project contains React components for teaching long division and multiplication.
+
+## Setup
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Build the project with:
+
+```bash
+npm run build
+```
+
+Serve the production build locally:
+
+```bash
+npm start
+```
+
+## Alias Configuration
+
+The code imports modules using the `@/` prefix, for example:
+
+```js
+import { Button } from '@/components/ui/button';
+```
+
+When using Vite, add the following alias configuration to `vite.config.js` so `@/` resolves to the project root:
+
+```js
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './')
+    }
+  }
+});
+```
+
+This allows absolute imports from the root directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "divide-like-a-king",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "start": "vite preview",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0",
+    "framer-motion": "^10.16.3",
+    "lucide-react": "^0.292.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add root package.json with React and Vite
- add Vite config including alias for `@/`
- document setup and alias usage in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496a8645dc8329bf59985ce0fac132