### PR TITLE
Add navigation header and RTL layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ npm install
 npm start
 ```
 
+If you pull new changes that update dependencies, run `npm install` again to
+ensure packages like **react-router-dom** are installed before starting the
+development server.
+
 Build the project with:
 
 ```bash

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -12,7 +12,8 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",
     "framer-motion": "^10.16.3",
-    "lucide-react": "^0.292.0"
+    "lucide-react": "^0.292.0",
+    "react-router-dom": "^6.21.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -1,7 +1,19 @@
-import Home from "./Pages/Home";
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Header from './Components/Header';
+import Home from './Pages/Home';
+import MultiplicationKing from './Pages/MultiplicationKing';
 
 function App() {
-  return <Home />;
+  return (
+    <>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/MultiplicationKing" element={<MultiplicationKing />} />
+      </Routes>
+    </>
+  );
 }
 
 export default App;

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders main header', () => {
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+  const heading = screen.getByText('מלך החילוק הארוך');
+  expect(heading).toBeInTheDocument();
 });

--- a/my-app/src/Components/Header.js
+++ b/my-app/src/Components/Header.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Crown } from 'lucide-react';
+
+export default function Header() {
+  return (
+    <header className="bg-white/80 backdrop-blur-sm border-b border-purple-100 shadow-sm sticky top-0 z-50">
+      <div className="max-w-6xl mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 bg-gradient-to-br from-purple-500 to-blue-500 rounded-2xl flex items-center justify-center shadow-lg">
+              <span className="text-2xl">🧮</span>
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">מלך החילוק הארוך</h1>
+              <p className="text-sm text-gray-500">למד חילוק ארוך בקלות ובכיף!</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link to="/MultiplicationKing">
+              <button className="justify-center whitespace-nowrap text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary hover:bg-primary/90 h-10 bg-gradient-to-r from-amber-400 to-orange-500 hover:from-amber-500 hover:to-orange-600 text-white font-bold shadow-lg flex items-center gap-2 transform hover:scale-105 transition-all duration-300 rounded-xl px-6 py-3 relative overflow-hidden">
+                <Crown className="w-5 h-5" />
+                מלך לוח הכפל
+                <div className="absolute inset-0 bg-gradient-to-r from-amber-300 to-orange-400 rounded-xl opacity-0 hover:opacity-20 transition-opacity duration-300"></div>
+              </button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/my-app/src/Components/division/StepController.js
+++ b/my-app/src/Components/division/StepController.js
@@ -112,6 +112,7 @@ export default function StepController({
               value={answer}
               onChange={(e) => setAnswer(e.target.value)}
               placeholder="תשובה..."
+              dir="ltr"
               className="text-center text-lg font-semibold border-2 focus:border-blue-400"
               autoFocus
             />

--- a/my-app/src/Pages/Home.js
+++ b/my-app/src/Pages/Home.js
@@ -189,46 +189,35 @@ export default function Home() {
   const currentStep = currentProblem.steps[currentStepIndex];
 
   return (
-    <div className="min-h-screen p-4 md:p-8">
-      <div className="max-w-7xl mx-auto">
-        
-        {/* Header */}
-        <div className="flex flex-col md:flex-row justify-between items-center mb-4 gap-4">
-          <div className="text-center md:text-right">
-            <h1 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent mb-2">
-              מלך החילוק הארוך
-            </h1>
-            <p className="text-gray-600">בואו נפתור יחד את התרגיל!</p>
+    <div dir="rtl" className="h-screen flex flex-col p-4 md:p-8">
+      <div className="max-w-7xl mx-auto flex flex-col flex-grow">
+        {/* Score and new problem button */}
+        <div className="flex justify-end items-center mb-4 gap-3">
+          <div className="bg-white rounded-2xl px-4 py-2 shadow-lg border border-purple-100">
+            <span className="text-purple-600 font-bold">ניקוד: {score}</span>
           </div>
-          
-          <div className="flex gap-3 items-center">
-            <div className="bg-white rounded-2xl px-4 py-2 shadow-lg border border-purple-100">
-              <span className="text-purple-600 font-bold">ניקוד: {score}</span>
-            </div>
-            <Button
-              onClick={generateNewProblem}
-              className="bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white flex items-center gap-2"
-            >
-              <RefreshCw className="w-5 h-5" />
-              תרגיל חדש
-            </Button>
-          </div>
+          <Button
+            onClick={generateNewProblem}
+            className="bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white flex items-center gap-2"
+          >
+            <RefreshCw className="w-5 h-5" />
+            תרגיל חדש
+          </Button>
         </div>
 
         {/* Display Current Problem */}
-        <div className="text-center mb-8">
+        <div className="text-center mb-4">
           <h2 dir="ltr" className="text-3xl md:text-4xl font-mono text-gray-700 bg-white/70 backdrop-blur-sm p-4 rounded-2xl shadow-md border border-gray-200 inline-block">
             {currentProblem.dividend} : {currentProblem.divisor}
           </h2>
         </div>
 
         {/* Game Content */}
-        <div className="grid lg:grid-cols-4 gap-8">
-          
-          {/* Division Grid - Takes up 3 columns */}
-          <div className="lg:col-span-3">
+        <div className="flex flex-col lg:flex-row gap-8 flex-grow overflow-hidden">
+          {/* Main column */}
+          <div className="lg:w-3/4 flex flex-col gap-8 h-full overflow-auto">
             {currentProblem && (
-              <div className="bg-gradient-to-br from-blue-50 to-purple-50 rounded-3xl p-8 border border-purple-100 mb-8">
+              <div className="bg-gradient-to-br from-blue-50 to-purple-50 rounded-3xl p-8 border border-purple-100">
                 <DivisionGrid
                   dividend={currentProblem.dividend}
                   divisor={currentProblem.divisor}
@@ -237,8 +226,7 @@ export default function Home() {
                 />
               </div>
             )}
-            
-            {/* Step Controller */}
+
             {currentStep && currentStepIndex < currentProblem?.steps?.length && (
               <StepController
                 currentStep={currentStep.type}
@@ -249,15 +237,14 @@ export default function Home() {
                 correctAnswer={currentStep.answer}
               />
             )}
-            
-            {/* Completion Message */}
+
             {currentProblem && currentStepIndex >= currentProblem.steps.length && (
               <motion.div
                 initial={{ scale: 0.8, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 className="text-center p-8 bg-gradient-to-r from-green-100 to-emerald-100 rounded-3xl border border-green-200"
               >
-                <motion.div 
+                <motion.div
                   className="text-6xl mb-4"
                   animate={{ rotate: [0, 10, -10, 0] }}
                   transition={{ duration: 0.5, repeat: 3 }}
@@ -295,9 +282,9 @@ export default function Home() {
               </motion.div>
             )}
           </div>
-          
-          {/* Progress Tracker - Takes up 1 column */}
-          <div className="lg:col-span-1">
+
+          {/* Progress Tracker */}
+          <div className="lg:w-1/4 overflow-auto">
             {currentStep && (
               <ProgressTracker
                 currentStep={currentStep.type}

--- a/my-app/src/Pages/MultiplicationKing.js
+++ b/my-app/src/Pages/MultiplicationKing.js
@@ -80,5 +80,6 @@ export default function MultiplicationKing() {
         </div>
       </div>
     </div>
+    </div>
   );
 }

--- a/my-app/src/Pages/MultiplicationKing.js
+++ b/my-app/src/Pages/MultiplicationKing.js
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Zap, Rows } from 'lucide-react';
 import PracticeMode from '../Components/multiplication/PracticeMode';
 import NumberSelection from '../Components/multiplication/NumberSelection';
+import Header from '../Components/Header';
 
 export default function MultiplicationKing() {
   const [mode, setMode] = useState(null); // 'fast', 'byNumber', or 'practice'
@@ -37,7 +38,9 @@ export default function MultiplicationKing() {
   }
 
   return (
-    <div className="min-h-screen p-4 md:p-8 flex items-center justify-center">
+    <div dir="rtl" className="min-h-screen flex flex-col">
+      <Header />
+      <div className="flex-1 p-4 md:p-8 flex items-center justify-center">
       <div className="max-w-2xl w-full text-center">
         <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-amber-500 to-orange-500 bg-clip-text text-transparent mb-4">
           מלך לוח הכפל

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  direction: rtl;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/my-app/src/index.js
+++ b/my-app/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -7,7 +8,9 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.17.0",
+    "react-router-dom": "^6.21.1",
     "framer-motion": "^10.16.3",
     "lucide-react": "^0.292.0"
   },


### PR DESCRIPTION
## Summary
- add a dedicated `Header` component with link to MultiplicationKing
- wire up React Router for navigation
- set global RTL direction and tweak Home page layout to avoid scrolling
- ensure math inputs are LTR
- update tests for new header

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b35fe8483299470eb01ba33cace