### PR TITLE
Fix header duplication and update MultiplicationKing header

### DIFF
--- a/my-app/src/Components/Header.js
+++ b/my-app/src/Components/Header.js
@@ -1,29 +1,45 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Crown } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
+import { Crown, Calculator } from 'lucide-react';
 
 export default function Header() {
+  const location = useLocation();
+  const isMultiplicationPage = location.pathname.includes("/MultiplicationKing");
+
   return (
     <header className="bg-white/80 backdrop-blur-sm border-b border-purple-100 shadow-sm sticky top-0 z-50">
       <div className="max-w-6xl mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 bg-gradient-to-br from-purple-500 to-blue-500 rounded-2xl flex items-center justify-center shadow-lg">
-              <span className="text-2xl">🧮</span>
+              <span className="text-2xl">{isMultiplicationPage ? '👑' : '🧮'}</span>
             </div>
             <div>
-              <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">מלך החילוק הארוך</h1>
-              <p className="text-sm text-gray-500">למד חילוק ארוך בקלות ובכיף!</p>
+              <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
+                {isMultiplicationPage ? 'מלך לוח הכפל' : 'מלך החילוק הארוך'}
+              </h1>
+              <p className="text-sm text-gray-500">
+                {isMultiplicationPage ? 'למד כפולות בקלות ובכיף!' : 'למד חילוק ארוך בקלות ובכיף!'}
+              </p>
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <Link to="/MultiplicationKing">
-              <button className="justify-center whitespace-nowrap text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary hover:bg-primary/90 h-10 bg-gradient-to-r from-amber-400 to-orange-500 hover:from-amber-500 hover:to-orange-600 text-white font-bold shadow-lg flex items-center gap-2 transform hover:scale-105 transition-all duration-300 rounded-xl px-6 py-3 relative overflow-hidden">
-                <Crown className="w-5 h-5" />
-                מלך לוח הכפל
-                <div className="absolute inset-0 bg-gradient-to-r from-amber-300 to-orange-400 rounded-xl opacity-0 hover:opacity-20 transition-opacity duration-300"></div>
-              </button>
-            </Link>
+            {isMultiplicationPage ? (
+              <Link to="/">
+                <button className="justify-center whitespace-nowrap text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary hover:bg-primary/90 h-10 bg-gradient-to-r from-purple-500 to-blue-500 hover:from-purple-600 hover:to-blue-600 text-white font-bold shadow-lg flex items-center gap-2 transform hover:scale-105 transition-all duration-300 rounded-xl px-6 py-3">
+                  <Calculator className="w-5 h-5" />
+                  מלך החילוק הארוך
+                </button>
+              </Link>
+            ) : (
+              <Link to="/MultiplicationKing">
+                <button className="justify-center whitespace-nowrap text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary hover:bg-primary/90 h-10 bg-gradient-to-r from-amber-400 to-orange-500 hover:from-amber-500 hover:to-orange-600 text-white font-bold shadow-lg flex items-center gap-2 transform hover:scale-105 transition-all duration-300 rounded-xl px-6 py-3 relative overflow-hidden">
+                  <Crown className="w-5 h-5" />
+                  מלך לוח הכפל
+                  <div className="absolute inset-0 bg-gradient-to-r from-amber-300 to-orange-400 rounded-xl opacity-0 hover:opacity-20 transition-opacity duration-300"></div>
+                </button>
+              </Link>
+            )}
           </div>
         </div>
       </div>

--- a/my-app/src/Pages/MultiplicationKing.js
+++ b/my-app/src/Pages/MultiplicationKing.js
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Zap, Rows } from 'lucide-react';
 import PracticeMode from '../Components/multiplication/PracticeMode';
 import NumberSelection from '../Components/multiplication/NumberSelection';
-import Header from '../Components/Header';
 
 export default function MultiplicationKing() {
   const [mode, setMode] = useState(null); // 'fast', 'byNumber', or 'practice'
@@ -39,7 +38,6 @@ export default function MultiplicationKing() {
 
   return (
     <div dir="rtl" className="min-h-screen flex flex-col">
-      <Header />
       <div className="flex-1 p-4 md:p-8 flex items-center justify-center">
       <div className="max-w-2xl w-full text-center">
         <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-amber-500 to-orange-500 bg-clip-text text-transparent mb-4">


### PR DESCRIPTION
## Summary
- fix duplicate header by removing internal header in MultiplicationKing page
- make Header component react to current route
- show crown icon and multiplication labels when visiting `/MultiplicationKing`
- allow navigation back to the long division home page from the header

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849937224648329a35bab70bf72ee6a